### PR TITLE
Report multiple lint / checkstyle warnings

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,13 +7,17 @@ if github.pr_title.include? "[WIP]"
     warn("PR is classed as Work in Progress - DO NOT MERGE")
 else
     # Android Lint
-    android_lint.skip_gradle_task = true
-    android_lint.report_file = "conveyor/build/reports/lint-results-debug.xml"
-    android_lint.lint
+    Dir["*/build/reports/lint-results-debug.xml"].each do |file|
+        android_lint.skip_gradle_task = true
+        android_lint.report_file = file
+        android_lint.lint
+    end
 
     # Kotlin Lint
-    checkstyle_format.base_path = Dir.pwd
-    checkstyle_format.report 'conveyor/build/reports/detekt/detekt.xml'
+    Dir["*/build/reports/detekt/detekt.xml"].each do |file|
+        checkstyle_format.base_path = Dir.pwd
+        checkstyle_format.report file
+    end
 end
 
 # Warn when there is a big PR

--- a/conveyor/src/test/java/com/hodamohammadi/conveyor/ExampleUnitTest.kt
+++ b/conveyor/src/test/java/com/hodamohammadi/conveyor/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package com.hodamohammadi.conveyor
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,10 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-android.enableD8.desugaring=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+
+android.enableD8.desugaring=true


### PR DESCRIPTION
Currently we are only reporting the main module reports. This PR adds support to report multiple modules. 