### PR TITLE
setting view model's scope to the fragments

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     // UI
     implementation "com.github.stfalcon:chatkit:${versions.chatkit}"
+    implementation "com.squareup.picasso:picasso:${versions.picasso}"
 
     // Firebase
     implementation "com.google.firebase:firebase-core:${versions.firebaseCore}"

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/fragments/ChatsListFragment.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/fragments/ChatsListFragment.kt
@@ -10,10 +10,10 @@ import android.widget.Toast
 import com.hodamohammadi.chat.R
 import com.hodamohammadi.chat.models.DefaultDialog
 import com.hodamohammadi.chat.utils.AppUtils
-import com.hodamohammadi.chat.viewmodels.ChatViewModel
+import com.hodamohammadi.chat.viewmodels.ChatsListViewModel
+import com.hodamohammadi.chat.viewmodels.SharedChatViewModel
 import com.hodamohammadi.chat.viewmodels.ViewModelFactory
 import com.hodamohammadi.navigation.RoutePath
-import com.hodamohammadi.navigations.features.ChatNavigation
 import com.hodamohammadi.navigations.loaders.loadFragmentOrNull
 import com.hodamohammadi.services.BaseResourceObserver
 import com.stfalcon.chatkit.commons.models.IDialog
@@ -32,7 +32,8 @@ class ChatsListFragment : Fragment(), DialogsListAdapter.OnDialogClickListener<I
     }
 
     private lateinit var dialogListAdapter: DialogsListAdapter<IDialog<IMessage>>
-    private lateinit var chatViewModel: ChatViewModel
+    private lateinit var sharedChatViewModel: SharedChatViewModel
+    private lateinit var chatsListViewModel: ChatsListViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,12 +45,14 @@ class ChatsListFragment : Fragment(), DialogsListAdapter.OnDialogClickListener<I
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        chatViewModel = ViewModelProviders.of(requireActivity(), ViewModelFactory)
-                .get(ChatViewModel::class.java)
+        sharedChatViewModel = ViewModelProviders.of(requireActivity(), ViewModelFactory)
+                .get(SharedChatViewModel::class.java)
+        chatsListViewModel = ViewModelProviders.of(this, ViewModelFactory)
+                .get(ChatsListViewModel::class.java)
 
         initAdapater()
 
-        chatViewModel.getUserDialogsLiveData
+        chatsListViewModel.getUserDialogsLiveData
                 .observe(this, object : BaseResourceObserver<List<DefaultDialog>>() {
             override fun onSuccess(data: List<DefaultDialog>?) {
                 super.onSuccess(data)
@@ -68,13 +71,13 @@ class ChatsListFragment : Fragment(), DialogsListAdapter.OnDialogClickListener<I
         dialogListAdapter = DialogsListAdapter(AppUtils.CustomImageLoader)
         dialogListAdapter.setOnDialogClickListener(this)
         dialogListAdapter.setOnDialogLongClickListener(this)
-        chatViewModel.getUserDialogs.value = null
+        chatsListViewModel.getUserDialogs.value = null
         dialogsList.setAdapter(dialogListAdapter)
     }
 
     override fun onDialogClick(dialog: IDialog<IMessage>?) {
         if (dialog != null && dialog.id != null) {
-            chatViewModel.threadId = dialog.id
+            sharedChatViewModel.threadId = dialog.id
             openSelectedChat()
         }
     }

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/utils/AppUtils.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/utils/AppUtils.kt
@@ -1,6 +1,7 @@
 package com.hodamohammadi.chat.utils
 
 import android.widget.ImageView
+import com.squareup.picasso.Picasso
 import com.stfalcon.chatkit.commons.ImageLoader
 
 /**
@@ -9,7 +10,7 @@ import com.stfalcon.chatkit.commons.ImageLoader
 class AppUtils {
     object CustomImageLoader : ImageLoader {
         override fun loadImage(imageView: ImageView, url: String?, payload: Any?) {
-            // TODO: set image.
+            Picasso.get().load(url).into(imageView);
         }
     }
 }

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/ChatsListViewModel.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/ChatsListViewModel.kt
@@ -4,32 +4,20 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
-import android.util.Log
 import com.hodamohammadi.chat.models.DefaultDialog
-import com.hodamohammadi.chat.models.DefaultMessage
-import com.hodamohammadi.services.gateways.FirebaseGateway
 import com.hodamohammadi.services.Resource
-import java.util.logging.Logger
+import com.hodamohammadi.services.gateways.FirebaseGateway
 
 /**
  * View model for communication between chat UIs.
  */
-class ChatViewModel : ViewModel() {
+class ChatsListViewModel : ViewModel() {
     val getUserDialogsLiveData: LiveData<Resource<List<DefaultDialog>>>
     val getUserDialogs = MutableLiveData<Void>()
-
-    val getThreadHistoryLiveData: LiveData<Resource<List<DefaultMessage>>>
-    val getThreadHistory = MutableLiveData<Void>()
-
-    var threadId: String? = null
 
     init {
         getUserDialogsLiveData = Transformations.switchMap(getUserDialogs){
             FirebaseGateway.getUserThreads()
-        }
-
-        getThreadHistoryLiveData = Transformations.switchMap(getThreadHistory){
-                FirebaseGateway.getThreadHistory(threadId!!)
         }
     }
 

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/SharedChatViewModel.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/SharedChatViewModel.kt
@@ -1,0 +1,34 @@
+package com.hodamohammadi.chat.viewmodels
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Transformations
+import android.arch.lifecycle.ViewModel
+import com.hodamohammadi.chat.models.DefaultDialog
+import com.hodamohammadi.chat.models.DefaultMessage
+import com.hodamohammadi.services.gateways.FirebaseGateway
+import com.hodamohammadi.services.Resource
+
+/**
+ * View model for communication between chat UIs.
+ */
+class SharedChatViewModel : ViewModel() {
+    val getUserDialogsLiveData: LiveData<Resource<List<DefaultDialog>>>
+    val getUserDialogs = MutableLiveData<Void>()
+
+    val getThreadHistoryLiveData: LiveData<Resource<List<DefaultMessage>>>
+    val getThreadHistory = MutableLiveData<Void>()
+
+    var threadId: String? = null
+
+    init {
+        getUserDialogsLiveData = Transformations.switchMap(getUserDialogs){
+            FirebaseGateway.getUserThreads()
+        }
+
+        getThreadHistoryLiveData = Transformations.switchMap(getThreadHistory){
+                FirebaseGateway.getThreadHistory(threadId!!)
+        }
+    }
+
+}

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/SingleChatViewModel.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/SingleChatViewModel.kt
@@ -1,0 +1,25 @@
+package com.hodamohammadi.chat.viewmodels
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Transformations
+import android.arch.lifecycle.ViewModel
+import com.hodamohammadi.chat.models.DefaultMessage
+import com.hodamohammadi.services.Resource
+import com.hodamohammadi.services.gateways.FirebaseGateway
+
+/**
+ * View model for communication between chat UIs.
+ */
+class SingleChatViewModel : ViewModel() {
+    val getThreadHistoryLiveData: LiveData<Resource<List<DefaultMessage>>>
+    val getThreadHistory = MutableLiveData<String>()
+
+    init {
+
+        getThreadHistoryLiveData = Transformations.switchMap(getThreadHistory){
+            FirebaseGateway.getThreadHistory(it!!)
+        }
+    }
+
+}

--- a/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/ViewModelFactory.kt
+++ b/chat/src/main/kotlin/com/hodamohammadi/chat/viewmodels/ViewModelFactory.kt
@@ -8,8 +8,12 @@ import android.arch.lifecycle.ViewModelProvider
  */
 object ViewModelFactory: ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return if (modelClass.isAssignableFrom(ChatViewModel::class.java)) {
-            ChatViewModel() as T
+        return if (modelClass.isAssignableFrom(SharedChatViewModel::class.java)) {
+            SharedChatViewModel() as T
+        } else if (modelClass.isAssignableFrom(SingleChatViewModel::class.java)) {
+            SingleChatViewModel() as T
+        } else if (modelClass.isAssignableFrom(ChatsListViewModel::class.java)) {
+            ChatsListViewModel() as T
         } else {
             throw IllegalArgumentException("ViewModel Not Found")
         }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -22,6 +22,7 @@ ext {
             // UI
             "chatkit"               : "0.3.3",
             "firebaseui"            : "4.3.1",
+            "picasso"               : "2.71828",
 
             // Testing
             "androidTestRunner"     : "1.0.2",


### PR DESCRIPTION
The data fetching live datas of the shared view model receive the previously posted data every time an observer is added so separating the view models for each fragment and using a shared view model only for sharing data between the fragments. 